### PR TITLE
Unit library management improvements

### DIFF
--- a/doc/processtrak_example/process_spectrum.prx
+++ b/doc/processtrak_example/process_spectrum.prx
@@ -8,6 +8,15 @@
     xmlns:ls="http://limatix.org/spreadsheet"
     xmlns:pt="http://limatix.org/processtrak">
   
+  <units_configuration forceuse="pint">
+    <lm_units>
+      <param name="configstring">"insert_basic_units"</param>
+    </lm_units>
+    <pint>
+      <param name="case_sensitive">False</param>
+    </pint>
+  </units_configuration>
+
   <inputfiles>
     <!-- Uncomment this <inputfile> tag to use spreadsheet input,
 	 along with the spreadsheet_like_datacollect.xsl converter

--- a/limatix/bin/processtrak.py
+++ b/limatix/bin/processtrak.py
@@ -75,8 +75,9 @@ except ImportError:
     from urllib.parse import urljoin
     pass
 
-from limatix import lm_units
-lm_units.units_config("insert_basic_units")
+# from limatix import lm_units
+# lm_units.units_config("insert_basic_units")
+
 from limatix import timestamp
 from limatix import canonicalize_path
 from limatix.canonicalize_path import etxpath2human
@@ -369,6 +370,10 @@ def main(args=None):
 
     #print("steps=%s" % str(steps))
 
+
+    # initialize unit configuration based on any specifications in the prx file
+    # todo: dont forget to turn off debug at some point
+    processtrak_common.setup_unit_configuration(prxdoc, debug=True)
 
     # Build dictionary by input file of output files
     outputdict=processtrak_common.build_outputdict(prxdoc,inputfiles_with_hrefs,ignore_locking)

--- a/limatix/processtrak_common.py
+++ b/limatix/processtrak_common.py
@@ -902,7 +902,7 @@ def setup_unit_configuration(prxdoc, debug=False):
     units_lib_to_use = units_configuration_element.attrib.get("forceuse", "lm_units")
 
     for child in units_configuration_element.getchildren():
-        kwargs = { param.attrib["name"]: ast.literal_eval(param.text) for param in child.getchildren() }
+        kwargs = { param.attrib["name"]: ast.literal_eval(param.text) for param in child.getchildren() if param.tag == "{%s}param" % prx_nsmap["prx"] }
         units.manager.set_configuration(etree.QName(child).localname, debug=debug, **kwargs)
 
     units.manager.set_backend(units_lib_to_use)

--- a/limatix/processtrak_common.py
+++ b/limatix/processtrak_common.py
@@ -68,6 +68,7 @@ if not hasattr(builtins,"unicode"):
 
 
 # import lm_units
+from limatix import units
 
 from . import timestamp
 from . import canonicalize_path
@@ -894,6 +895,18 @@ def getinputfiles(prxdoc):
         pass
 
     return (inputfiles_element,inputfiles_with_hrefs)
+
+
+def setup_unit_configuration(prxdoc, debug=False):
+    units_configuration_element = prxdoc.xpathsinglecontext(prxdoc.getroot(), "prx:units_configuration", None)
+    units_lib_to_use = units_configuration_element.attrib.get("forceuse", "lm_units")
+
+    for child in units_configuration_element.getchildren():
+        kwargs = { param.attrib["name"]: ast.literal_eval(param.text) for param in child.getchildren() }
+        units.manager.set_configuration(etree.QName(child).localname, debug=debug, **kwargs)
+
+    units.manager.set_backend(units_lib_to_use)
+    pass
 
 
 def build_outputdict(prxdoc,useinputfiles_with_hrefs,ignore_locking=False):

--- a/limatix/processtrak_procstep.py
+++ b/limatix/processtrak_procstep.py
@@ -1145,6 +1145,7 @@ def procsteppython_do_run(stepglobals,runfunc,argkw,ipythonmodelist,action,scrip
                 for syntreenode in ast.walk(runfunc_syntaxtree):
                     if hasattr(syntreenode,"lineno"):
                         syntreenode.lineno+=startinglineno+lines_to_delete-1-1
+                        syntreenode.end_lineno+=startinglineno+lines_to_delete-1-1
                         pass
                     # record calling function node
                     for child in ast.iter_child_nodes(syntreenode):

--- a/limatix/units.py
+++ b/limatix/units.py
@@ -1,0 +1,386 @@
+import re
+import builtins
+import numbers
+
+from . import lm_units  # note: main program should call lm_units.units_config("insert_basic_units")
+from . import dc_value
+
+HAS_PINT = False
+try:
+    import pint
+    HAS_PINT = True
+except ImportError:
+    pass
+
+
+if not hasattr(builtins,"basestring"):
+    basestring=str  # python3
+    pass
+
+
+class LimatixUnitManager():
+    _registry = None
+    _backend = "lm_units"
+
+    def __init__(self) -> None:
+        self._registry = self.get_application_registry_pint()
+        pass
+
+    @property
+    def backend(self):
+        return self._backend
+
+    @property
+    def registry(self):
+        return self._registry.get()
+
+    @property
+    def Q(self):
+        return self._registry.get().Quantity
+
+    def set_backend(self, backend="lm_units"):
+        if (backend == "pint") and not HAS_PINT:
+            raise ValueError("pint unit library is not installed")
+
+        if (backend != "pint") and (backend != "lm_units"):
+            raise ValueError("invalid backend %s, must be lm_units or pint" % backend)
+
+        self._backend = backend
+        pass
+
+    def set_configuration(self, backend, debug=False, **kwargs):
+        if debug:
+            print("Debug: setting unit configuration for %s backend" % backend)
+            print("configuration parameters:")
+            for p, v in kwargs.items(): print("%s=%s" % (p, v))
+
+        if backend == "lm_units":
+            lm_units.units_config(kwargs.get("configstring", "insert_basic_units"))
+        elif backend == "pint":
+            if not HAS_PINT:
+                print("Warning: trying to specify configuration for pint but it is not installed. configuration parameters will be ignored")
+                return
+            self.set_application_registry_pint(pint.UnitRegistry(**kwargs))
+        else:
+            raise NotImplementedError("unit backend %s is unavailable" % backend)
+        pass
+
+    def get_application_registry_pint(self):
+        return pint.get_application_registry() if HAS_PINT else None
+
+    def set_application_registry_pint(self, registry):
+        pint.set_application_registry(registry)
+        self._registry = self.get_application_registry_pint()
+        pass
+
+    def parse(self, val, units):
+        quantity = self.registry.parse_expression("%s %s" % (val, units))
+
+        if units is None:
+            matchobj=re.match(R""" *(([-+]?(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?)|([-+]?[iI][nN][fF])|([nN][aA][nN])) *[\[]?([^\]\[]*)[\]]?""",val);
+            if matchobj is not None :
+                val=float(matchobj.group(1))
+                unit=lm_units.parseunits(matchobj.group(8))
+                pass
+            pass
+        else :
+            val=float(val)                
+            if isinstance(units, basestring):
+                unit=lm_units.parseunits(units);
+                pass
+            else :
+                unit=lm_units.copyunits(units);
+                pass
+            pass
+
+        return val, unit, quantity
+
+    def from_numericunitsvalue(self, val, units=None):
+        quantity = self.Q(val.value(), str(val.units()) if val.units() is not None else units)
+
+        # val is already a dc_value object
+        if units is None:
+            val=val.value()
+            unit=val.units()
+            pass
+        else : 
+            if isinstance(units,basestring):
+                unitstruct=lm_units.parseunits(units)
+                pass
+            else: 
+                unitstruct=units
+                pass
+            
+            val=val.value(unitstruct)
+            unit=lm_units.copyunits(unitstruct)
+            pass
+
+        return val, unit, quantity
+
+    def from_value(self, val, units=None):
+        quantity = self.Q(val, str(units) if units is not None else None)
+
+        if units is not None:
+            if isinstance(units,basestring):
+                unit=lm_units.parseunits(units);
+                pass
+            else :
+                unit=lm_units.copyunits(units);
+                pass
+            pass
+
+        return val, unit, quantity
+
+    def equal(self, v1, v2):
+        if self.backend == "pint":
+            if isinstance(v2, dc_value.numericunitsvalue):
+                v2 = v2.quantity
+            return v1.quantity == v2
+        else:
+            # print "NumericUnitsValue Eq called!"
+            # print self.val==other.value(),self.unit==other.units()
+            # print str(self.unit),str(other.units())
+
+            otherval=v2.value()
+            otherunit=v2.units()
+            
+            # print "self.val=%s, otherval=%s" % (str(self.val),str(otherval))
+            # print "self.unit=%s, otherunit=%s" % (str(self.unit),str(otherunit))
+            unitfactor=lm_units.compareunits(v1.unit,otherunit)
+            unitfactor2=lm_units.compareunits(otherunit,v1.unit)
+            if unitfactor==0.0 or unitfactor2==0.0:
+                # unit mismatch
+                return False
+            else :
+                # avoid roundoff issues by checking strict equality both ways
+                if v1.val*unitfactor==otherval or v1.val==otherval*unitfactor2:
+                    return True
+                else :
+                    return False
+
+    def less_than(self, v1, v2):
+        if self.backend == "pint":
+            if isinstance(v2, dc_value.numericunitsvalue):
+                v2 = v2.quantity
+            return v1.quantity < v2
+        else:
+            if isinstance(v2,numbers.Number):
+                unitfactor = lm_units.compareunits(v1.unit, lm_units.createunits())            
+                value = v2
+                pass        
+            else:
+                unitfactor = lm_units.compareunits(v1.unit, v2.units())
+                value = v2.value()
+                pass
+            if unitfactor == 0.0:
+                raise ValueError("Attempting to add values with incompatible units %s and %s" % (str(v1.unit), str(v2.units())))
+            
+            return v1.val < (value / unitfactor)
+
+    def less_than_equal(self, v1, v2):
+        if self.backend == "pint":
+            if isinstance(v2, dc_value.numericunitsvalue):
+                v2 = v2.quantity
+            return v1.quantity <= v2
+        else:
+            if isinstance(v2, numbers.Number):
+                unitfactor=lm_units.compareunits(v1.unit, lm_units.createunits())            
+                value=v2
+                pass        
+            else:
+                unitfactor=lm_units.compareunits(v1.unit, v2.units())
+                value=v2.value()
+                pass
+            if unitfactor == 0.0:
+                raise ValueError("Attempting to add values with incompatible units %s and %s" % (str(v1.unit), str(v2.units())))
+            
+            return v1.val <= (value / unitfactor)
+
+    def greater_than(self, v1, v2):
+        if self.backend == "pint":
+            if isinstance(v2, dc_value.numericunitsvalue):
+                v2 = v2.quantity
+            return v1.quantity > v2
+        else:
+            if isinstance(v2,numbers.Number):
+                unitfactor=lm_units.compareunits(v1.unit, lm_units.createunits())            
+                value=v2
+                pass        
+            else:
+                unitfactor=lm_units.compareunits(v1.unit, v2.units())
+                value=v2.value()
+                pass
+            if unitfactor == 0.0:
+                raise ValueError("Attempting to add values with incompatible units %s and %s" % (str(v1.unit), str(v2.units())))
+            
+            return v1.val > (value / unitfactor)
+
+    def greater_than_equal(self, v1, v2):
+        if self.backend == "pint":
+            if isinstance(v2, dc_value.numericunitsvalue):
+                v2 = v2.quantity
+            return v1.quantity >= v2
+        else:
+            if isinstance(v2, numbers.Number):
+                unitfactor = lm_units.compareunits(v1.unit, lm_units.createunits())            
+                value=v2
+                pass        
+            else:
+                unitfactor = lm_units.compareunits(v1.unit, v2.units())
+                value = v2.value()
+                pass
+            if unitfactor == 0.0:
+                raise ValueError("Attempting to add values with incompatible units %s and %s" % (str(v1.unit), str(v2.units())))
+            
+            return v1.val >= (value / unitfactor)
+
+    def absolute_value(self, v):
+        if self.backend == "pint":
+            v = abs(v.quantity)
+            return dc_value.numericunitsvalue(v.m, v.units)
+        else:
+            return dc_value.numericunitsvalue(abs(v.val), v.unit)
+
+    def round(self, v):
+        if self.backend == "pint":
+            v = round(v.quantity)
+            return dc_value.numericunitsvalue(v.m, v.units)
+        else:
+            return dc_value.numericunitsvalue(round(v.val), v.unit)
+
+    def power(self, v, p, modulo=None):
+        if self.backend == "pint":
+            if isinstance(p,dc_value.numericunitsvalue):
+                p = p.quantity
+                pass
+
+            v = v.quantity**p
+            return dc_value.numericunitsvalue(v.m, v.units)
+        else:
+            if modulo is not None:
+                raise ValueError("pow modulo not supported")
+
+            if isinstance(p, dc_value.numericunitsvalue):
+                p=p.value("") # need unitless representation of exponent
+                pass
+            
+            return dc_value.numericunitsvalue(v.val**p, lm_units.powerunits(v.unit, p))
+
+        pass
+    
+    def add(self, v1, v2):
+        if self.backend == "pint":
+            if isinstance(v2, dc_value.numericunitsvalue):
+                v2 = v2.quantity
+            v1 = v1.quantity + v2
+            return dc_value.numericunitsvalue(v1.m, v1.units)
+        else:
+            if isinstance(v2, numbers.Number):
+                unitfactor = lm_units.compareunits(v1.unit, lm_units.createunits())            
+                value = v2
+                pass        
+            else:
+                unitfactor = lm_units.compareunits(v1.unit, v2.units())
+                value = v2.value()
+                pass
+            if unitfactor == 0.0:
+                raise ValueError("Attempting to add values with incompatible units %s and %s" % (str(v1.unit), str(v2.units())))
+            
+            return dc_value.numericunitsvalue(v1.val + value/unitfactor, v2.unit)
+
+    def subtract(self, v1, v2):
+        if self.backend == "pint":
+            if isinstance(v2, dc_value.numericunitsvalue):
+                v2 = v2.quantity
+            v1 = v1.quantity - v2
+            return dc_value.numericunitsvalue(v1.m, v1.units)
+        else:
+            if isinstance(v2, numbers.Number):
+                unitfactor = lm_units.compareunits(v1.unit, lm_units.createunits())
+                value = v2
+                pass        
+            else:
+                unitfactor = lm_units.compareunits(v1.unit, v2.units())
+                value = v2.value()
+                pass
+            
+            if unitfactor == 0.0:
+                raise ValueError("Attempting to add values with incompatible units %s and %s" % (str(v1.unit), str(v2.units())))
+            
+            return dc_value.numericunitsvalue(v1.val - value/unitfactor, v2.unit)
+    
+    def multiply(self, v1, v2):
+        if self.backend == "pint":
+            if isinstance(v2, dc_value.numericunitsvalue):
+                v2 = v2.quantity
+            v1 = v1.quantity * v2
+            return dc_value.numericunitsvalue(v1.m, v1.units)
+        else:
+            if not isinstance(v2, float):
+                newunits = lm_units.multiplyunits(v1.unit, v2.units())
+                tomul = v2.value()
+                pass
+            else:
+                newunits = v1.unit
+                tomul = v2
+                pass
+            
+            return dc_value.numericunitsvalue(v1.val*tomul, newunits)
+    
+    def divide(self, v1, v2):
+        if self.backend == "pint":
+            if isinstance(v2, dc_value.numericunitsvalue):
+                v2 = v2.quantity
+            v1 = v1.quantity / v2
+            return dc_value.numericunitsvalue(v1.m, v1.units)
+        else:
+            if not isinstance(v2,float):
+                newunits = lm_units.divideunits(v1.unit, v2.units())
+                todiv = v2.value()
+                pass
+            else:
+                newunits = v1.unit
+                todiv = v2
+                pass
+
+            return dc_value.numericunitsvalue(v1.val/todiv, newunits)
+
+    def true_divide(self, v1, v2):
+        if self.backend == "pint":
+            if isinstance(v2, dc_value.numericunitsvalue):
+                v2 = v2.quantity
+            v1 = v1.quantity / v2
+            return dc_value.numericunitsvalue(v1.m, v1.units)
+        else:
+            if not isinstance(v2, float):
+                newunits = lm_units.divideunits(v1.unit, v2.units())
+                todiv = v2.value()
+                pass
+            else:
+                newunits = v1.unit
+                todiv = v2
+                pass
+            
+            return dc_value.numericunitsvalue(v1.val/todiv, newunits);
+
+    def floor_divide(self, v1, v2):
+        if self.backend == "pint":
+            if isinstance(v2, dc_value.numericunitsvalue):
+                v2 = v2.quantity
+            v1 = v1.quantity // v2
+            return dc_value.numericunitsvalue(v1.m, v1.units)
+        else:
+            if not isinstance(v2, float):
+                newunits = lm_units.divideunits(v1.unit, v2.units())
+                todiv = v2.value()
+                pass
+            else:
+                newunits = v1.unit
+                todiv = v2
+                pass
+
+            return dc_value.numericunitsvalue(v1.val//todiv, newunits);
+
+    pass
+
+manager = LimatixUnitManager()


### PR DESCRIPTION
Created a LimatixUnitManager class which handles all unit operations by passing them through to a specific unit backend (lm_units or pint).

The user can specify configurations for any unit backend in the prx file by specifying element blocks with the format: "prx:<backend_name>". Elements within these blocks with the tag "prx:param" will be parsed as configuration parameters and passed to the respective unit library.

The attribute "forceuse" can be used to override the default unit backend (lm_units) if that backend is installed.

For example:
```
<prx:units_configuration forceuse="pint">
  <prx:lm_units>
    <prx:param name="configstring">"insert_basic_units"</prx:param>
  </prx:lm_units>
  <prx:pint>
    <prx:param name="case_sensitive">False</prx:param>
  </prx:pint>
</prx:units_configuration>
````

In pint support, specifically, users can manually specify/update the application level registry by calling LimatixUnitManager.set_application_registry_pint. This will update pints application level registry and update the registry used by LimatixUnitManager.

Processtrak demo was updated to utilize the new functionality.

Known issues:

- Previously lm_units was initialized by a hardcoded default in processtrak. Now it requires the user to specify that default in the .prx.
- Currently, only functions related to dc_value.numericunitsvalue are passed through the LimatixUnitManager.

Additional fixes:

- Fixed missing .end_lineno assignment for newer versions of ast/python.